### PR TITLE
Allow correction range target down to 70 mg/dL

### DIFF
--- a/patches/allow-correction-range-70.patch
+++ b/patches/allow-correction-range-70.patch
@@ -1,0 +1,15 @@
+diff --git a/LoopKit/Extensions/Guardrail+Settings.swift b/LoopKit/Extensions/Guardrail+Settings.swift
+--- a/LoopKit/Extensions/Guardrail+Settings.swift
++++ b/LoopKit/Extensions/Guardrail+Settings.swift
+@@ -23,7 +23,10 @@ public extension Guardrail where Value == HKQuantity {
+         .compactMap { $0 }
+         .min()!
+     }
+ 
+-    static let correctionRange = Guardrail(absoluteBounds: (86.1)...(180.5), recommendedBounds: (99.1)...(115.9), unit: .milligramsPerDeciliter, startingSuggestion: 100)
++    // Allow setting the correction range as low as 70 mg/dL (~3.9 mmol/L).
++    // The fractional lower bound preserves the intended mmol/L conversion and rounding behavior.
++    static let correctionRange = Guardrail(absoluteBounds: (69.1)...(180.5), recommendedBounds: (69.1)...(115.9), unit: .milligramsPerDeciliter, startingSuggestion: 100)
+ 
+     static func minCorrectionRangeValue(suspendThreshold: GlucoseThreshold?) -> HKQuantity {
+         return [


### PR DESCRIPTION
## Summary
- add a LoopWorkspace patch that lowers the correction range guardrail minimum from 86.1 mg/dL to 69.1 mg/dL
- lower the recommended lower bound as well so 70 mg/dL can be selected without showing as out-of-range
- document in the patch why the lower bound uses `69.1` rather than `70` to preserve mmol/L rounding behavior

## Notes
This change is added as a `patches/*.patch` file because `LoopKit` is included in `LoopWorkspace` as a submodule, and browser-build customizations are typically applied from the workspace patch directory.
